### PR TITLE
[Issue 8, US-08] See transcription

### DIFF
--- a/ts-back/src/media/media.controller.ts
+++ b/ts-back/src/media/media.controller.ts
@@ -241,4 +241,22 @@ export class MediaController {
       },
     };
   }
+
+  @Get(':id/transcription')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  async getTranscription(@Param('id') id: string, @Request() req) {
+    const file = await this.mediaService.findById(id);
+
+    if (!file) {
+      throw new NotFoundException('File not found');
+    }
+
+    // Verify file ownership
+    if (file.userId.toString() !== req.user.sub) {
+      throw new ForbiddenException('You do not have permission to view this transcription');
+    }
+
+    return this.mediaService.getTranscription(id);
+  }
 }

--- a/ts-back/test/media-transcription-get.e2e-spec.ts
+++ b/ts-back/test/media-transcription-get.e2e-spec.ts
@@ -1,0 +1,241 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { Connection, Types } from 'mongoose';
+import { getConnectionToken } from '@nestjs/mongoose';
+
+describe('MediaController - GET /media/:id/transcription (e2e)', () => {
+  let app: INestApplication;
+  let connection: Connection;
+  let authToken: string;
+  let secondUserToken: string;
+  let fileId: string;
+  let secondUserFileId: string;
+
+  const uniqueTimestamp = Date.now();
+  const testUser = {
+    username: `tuser${uniqueTimestamp}`,
+    email: `tuser${uniqueTimestamp}@test.com`,
+    password: 'password123',
+  };
+
+  const secondUser = {
+    username: `suser${uniqueTimestamp}`,
+    email: `suser${uniqueTimestamp}@test.com`,
+    password: 'password123',
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    connection = moduleFixture.get<Connection>(getConnectionToken());
+
+    // Clean up any existing users with these emails
+    await connection.collection('users').deleteMany({
+      email: { $in: [testUser.email, secondUser.email] },
+    });
+
+    // Register and login test user
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(testUser)
+      .expect(201);
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: testUser.email,
+        password: testUser.password,
+      })
+      .expect(200);
+
+    authToken = loginResponse.body.accessToken;
+
+    // Register and login second user
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(secondUser)
+      .expect(201);
+
+    const secondLoginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: secondUser.email,
+        password: secondUser.password,
+      })
+      .expect(200);
+
+    secondUserToken = secondLoginResponse.body.accessToken;
+
+    // Upload a test file for the first user
+    const uploadResponse = await request(app.getHttpServer())
+      .post('/media/upload')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('file', Buffer.from('test audio content'), 'test.mp3')
+      .expect(201);
+
+    fileId = uploadResponse.body.file.id;
+
+    // Upload a test file for the second user
+    const secondUploadResponse = await request(app.getHttpServer())
+      .post('/media/upload')
+      .set('Authorization', `Bearer ${secondUserToken}`)
+      .attach('file', Buffer.from('test audio content 2'), 'test2.mp3')
+      .expect(201);
+
+    secondUserFileId = secondUploadResponse.body.file.id;
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    if (connection) {
+      await connection.collection('users').deleteMany({
+        email: { $in: [testUser.email, secondUser.email] },
+      });
+      await connection.collection('mediafiles').deleteMany({
+        _id: { $in: [fileId, secondUserFileId].filter(Boolean).map(id => new Types.ObjectId(id)) },
+      });
+    }
+    await app.close();
+  });
+
+  describe('GET /media/:id/transcription', () => {
+    it('should return message for file in ready status', () => {
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('status', 'ready');
+          expect(res.body).toHaveProperty('message', 'Transcription has not been started yet');
+          expect(res.body).not.toHaveProperty('transcription');
+        });
+    });
+
+    it('should return 401 without authentication', () => {
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .expect(401);
+    });
+
+    it('should return 403 for file owned by another user', () => {
+      return request(app.getHttpServer())
+        .get(`/media/${secondUserFileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(403)
+        .expect((res) => {
+          expect(res.body.message).toBe('You do not have permission to view this transcription');
+        });
+    });
+
+    it('should return 404 for non-existent file', () => {
+      const fakeId = '507f1f77bcf86cd799439011';
+      return request(app.getHttpServer())
+        .get(`/media/${fakeId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).toBe('File not found');
+        });
+    });
+
+    it('should return processing status when file is being processed', async () => {
+      // Update file status to processing
+      await request(app.getHttpServer())
+        .patch(`/media/${fileId}/status`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ status: 'processing', progress: 50 })
+        .expect(200);
+
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('status', 'processing');
+          expect(res.body).toHaveProperty('progress', 50);
+          expect(res.body).toHaveProperty('message', 'Transcription is in progress');
+          expect(res.body).not.toHaveProperty('transcription');
+        });
+    });
+
+    it('should return error status when transcription failed', async () => {
+      const errorMessage = 'Test error: transcription service unavailable';
+      
+      // Update file status to error
+      await request(app.getHttpServer())
+        .patch(`/media/${fileId}/status`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ status: 'error', errorMessage })
+        .expect(200);
+
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('status', 'error');
+          expect(res.body).toHaveProperty('message', errorMessage);
+          expect(res.body).not.toHaveProperty('transcription');
+        });
+    });
+
+    it('should return transcription for completed file', async () => {
+      const transcribedText = 'This is a test transcription';
+      
+      // Manually update the file in database to have completed status with transcription
+      await connection.collection('mediafiles').updateOne(
+        { _id: new Types.ObjectId(fileId) },
+        { 
+          $set: { 
+            status: 'completed', 
+            progress: 100,
+            transcribedText 
+          } 
+        }
+      );
+
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('status', 'completed');
+          expect(res.body).toHaveProperty('transcription', transcribedText);
+          expect(res.body).toHaveProperty('fileId', fileId);
+          expect(res.body).toHaveProperty('originalFilename');
+        });
+    });
+
+    it('should return 500 if completed file has no transcribed text', async () => {
+      // Manually update file to have completed status without transcription
+      await connection.collection('mediafiles').updateOne(
+        { _id: new Types.ObjectId(fileId) },
+        { 
+          $set: { 
+            status: 'completed', 
+            progress: 100 
+          },
+          $unset: {
+            transcribedText: ''
+          }
+        }
+      );
+
+      return request(app.getHttpServer())
+        .get(`/media/${fileId}/transcription`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(500)
+        .expect((res) => {
+          expect(res.body.message).toContain('Transcription text not available');
+        });
+    });
+  });
+});


### PR DESCRIPTION
This pull request implements the "View Transcription" feature (US-08), enabling secure, status-aware access to transcribed text for uploaded media files. It introduces a new backend API endpoint to retrieve transcription results, enforces authentication and ownership validation, and provides thorough documentation and automated tests. The frontend already supports viewing transcriptions, so no UI changes are required, but the new endpoint is ready for future optimizations.

**Backend: Transcription Retrieval Endpoint**
- Adds GET `/media/:id/transcription` endpoint in `MediaController` with JWT authentication and file ownership checks; returns transcription or status-specific responses for each file state.
- Implements `getTranscription` method in `MediaService` to return type-safe, status-aware responses, handling all edge cases and error conditions.

**Testing**
- Adds comprehensive unit tests for `MediaService.getTranscription`, covering all file statuses and error scenarios.
- Adds end-to-end tests for the new endpoint, verifying authentication, authorization, file status handling, and error responses, with MongoDB state manipulation for accurate simulation.

**Documentation**
- Updates `README.md` and `.github/copilot-instructions.md` with detailed API documentation, response examples, error codes, feature description, and best practices for using the new endpoint. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R127) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R534-R609) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R555-R661)

**Integration**
- Ensures the new endpoint integrates seamlessly with the existing dashboard and supports real-time updates via WebSocket, maintaining data privacy and preparing for future frontend enhancements.